### PR TITLE
Fix typo in 8.markdown

### DIFF
--- a/getting_started/8.markdown
+++ b/getting_started/8.markdown
@@ -71,7 +71,7 @@ Elixir projects are usually organized into three directories:
 
 * ebin - コンパイルされたバイトコードが入っています
 * lib - Elixirのコードが入っています(たいてい`.ex`というファイルです)
-* test - テストが入っています(たいて`.exs`というファイルです)
+* test - テストが入っています(たいてい`.exs`というファイルです)
 
 * ebin - contains the compiled bytecode
 * lib - contains elixir code (usually `.ex` files)


### PR DESCRIPTION
I found a typo in 8.markdown.
Please merge this pullreq.
