### PR TITLE
Replace pygments with highlighter

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 markdown: redcarpet
-pygments: true
+highliter: true
 permalink: /blog/:year/:month/:day/:title
 redcarpet:
   extensions: ['with_toc_data']


### PR DESCRIPTION
https://github.com/jekyll/jekyll-help/issues/48
pygments is deprecated.
